### PR TITLE
Use npm to trigger grunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Boilerplate code for a simple webapp
 * `git clone https://github.com/sitevision/webapp-boilerplate.git`
 * `cd webapp-boilerplate`
 * `npm install`
-* `grunt setup`
+* `npm run setup`
 ## Building 
-* `grunt zip` compress `/src` into `/dist`
-* `grunt deploy` compress `/src` into `/dist` and upload to the addon configured in the setup task 
+* `npm run zip` compress `/src` into `/dist`
+* `npm run deploy` compress `/src` into `/dist` and upload to the addon configured in the setup task 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "type": "git",
     "url": "git+https://github.com/sitevision/webapp-boilerplate.git"
   },
+  "scripts": {
+    "setup": "grunt setup",
+    "zip": "grunt zip",
+    "deploy": "grunt deploy"
+  },
   "license": "MIT",
   "author": "SiteVision AB",
   "bugs": {


### PR DESCRIPTION
"Hide" the build tool from the developer and run the scripts from npm instead. Then the build tool can be changed without changing the commands to run. And it is more consistent with envision.

😃