### PR TITLE
Add Support for using siteNames that has to be URL-encoded.

### DIFF
--- a/util/create-addon.js
+++ b/util/create-addon.js
@@ -1,10 +1,11 @@
 var
    request       = require('request');
    properties    = require('../util/properties');
+   queryString   = require('querystring');
 
 (function () {
    var props = properties.getDevProperties(),
-      url = `https://${props.username}:${props.password}@${props.domain}/rest-api/1/0/${props.siteName}/Addon%20Repository/custommodule`;
+      url = `https://${props.username}:${props.password}@${props.domain}/rest-api/1/0/${queryString.escape(props.siteName)}/Addon%20Repository/custommodule`;
 
    request.post({url: url, form: {name: props.addonName, category: 'Other'}}, (err, httpResponse, body) => {
       if (err) {

--- a/util/deploy.js
+++ b/util/deploy.js
@@ -4,10 +4,11 @@ var
    fs            = require('fs'),
    request       = require('request');
    properties    = require('../util/properties');
+   queryString   = require('querystring');
 
 (function () {
    var props = properties.getDevProperties(),
-      url = `https://${props.username}:${props.password}@${props.domain}/rest-api/1/0/${props.siteName}/Addon%20Repository/${props.addonName}/webAppImport`,
+      url = `https://${props.username}:${props.password}@${props.domain}/rest-api/1/0/${queryString.escape(props.siteName)}/Addon%20Repository/${props.addonName}/webAppImport`,
       manifest = properties.getManifest(),
       formData = {
          file: fs.createReadStream(properties.DIST_DIR_PATH + '/' + manifest.id + '.zip')
@@ -25,7 +26,7 @@ var
       if (httpResponse.statusCode === 200) {
          return console.log('Upload successful: \n', JSON.stringify(JSON.parse(body), null, 2));
       }
-      
+
       console.log('Upload failed: \n', JSON.stringify(JSON.parse(body), null, 2));
    });
 })();

--- a/util/prod-deploy.js
+++ b/util/prod-deploy.js
@@ -3,6 +3,7 @@ var
    fs          = require('fs'),
    request     = require('request'),
    properties  = require('../util/properties');
+   queryString = require('querystring');
 
 (function () {
    var props = properties.getDevProperties(),
@@ -34,7 +35,7 @@ var
       ];
 
    inquirer.prompt(questions).then(answers => {
-      var url = `https://${answers.username}:${answers.password}@${answers.domain}/rest-api/1/0/${answers.siteName}/Addon%20Repository/${answers.addonName}/webAppImport`,
+      var url = `https://${answers.username}:${answers.password}@${answers.domain}/rest-api/1/0/${queryString.escape(answers.siteName)}/Addon%20Repository/${answers.addonName}/webAppImport`,
          manifest = properties.getManifest(),
          formData = {
             file: fs.createReadStream(properties.DIST_DIR_PATH + '/' + manifest.id + '-signed.zip')


### PR DESCRIPTION
Adds support for allowing site names that has to be URL-encoded to run several of the scripts that push to SiteVision (this includes names containing åäö) without the need to enter the URL-encoded version during setup.